### PR TITLE
Add Verb Confirmation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -504,6 +504,11 @@
         "minimist": "^1.2.0"
       }
     },
+    "@cyber4all/clark-taxonomy": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@cyber4all/clark-taxonomy/-/clark-taxonomy-4.0.2.tgz",
+      "integrity": "sha512-8lY8HIHdSQPDZuGC4OGMGKYe8Q1SG5LuW7vye1skhSGU/UgNbFafdXHhm03zNlIIUknUVbgE25rXeP8yNswYvA=="
+    },
     "@hapi/address": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/@hapi/address/-/address-2.1.4.tgz",
@@ -1869,6 +1874,14 @@
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
       "dev": true
+    },
+    "@types/jsonfile": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/jsonfile/-/jsonfile-4.0.2.tgz",
+      "integrity": "sha512-t2mJsD2YCfEPxqJKND4TubLMBdIPcMZS3UdjlUhZLL+vQceptLgrd2nBRUlP/8/YcgM4wC9PWXWKW3Nb1kFS4Q==",
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@types/jsonwebtoken": {
       "version": "8.3.8",
@@ -6033,8 +6046,7 @@
     "graceful-fs": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
-      "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
-      "dev": true
+      "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ=="
     },
     "growly": {
       "version": "1.3.0",
@@ -9629,7 +9641,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-      "dev": true,
       "requires": {
         "graceful-fs": "^4.1.6"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "outcome-service",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "outcome-service",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "",
   "author": "",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "server-test": "start-server-and-test start http://localhost:3000 test"
   },
   "dependencies": {
+    "@cyber4all/clark-taxonomy": "^4.0.2",
     "@nestjs/common": "^6.10.14",
     "@nestjs/config": "^0.4.0",
     "@nestjs/core": "^6.10.14",

--- a/src/DTO/OutcomeWrite.DTO.ts
+++ b/src/DTO/OutcomeWrite.DTO.ts
@@ -1,6 +1,12 @@
 import { IsNotEmpty, IsDefined, IsString, IsIn, MaxLength } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
+import { taxonomy } from '@cyber4all/clark-taxonomy';
 
+const verbs = {
+    'remember and understand': taxonomy.taxons['remember and understand'].verbs,
+    'apply and analyze': taxonomy.taxons['apply and analyze'].verbs,
+    'evaluate and synthesize': taxonomy.taxons['evaluate and synthesize'].verbs,
+}
 export class OutcomeWriteDTO {
 
     @ApiProperty({
@@ -45,6 +51,7 @@ export class OutcomeWriteDTO {
     @IsDefined()
     @IsNotEmpty()
     @IsString()
-    verb: string; // TODO: required, must be a verb within the list for the selected bloom
+    @IsIn(verbs[this.bloom])
+    verb: string;
 
 }

--- a/src/DTO/OutcomeWrite.DTO.ts
+++ b/src/DTO/OutcomeWrite.DTO.ts
@@ -1,7 +1,7 @@
 import { IsNotEmpty, IsDefined, IsString, IsIn, MaxLength } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
 import { taxonomy } from '@cyber4all/clark-taxonomy';
-
+import { IsVerbInBloom } from './verbValidation';
 const verbs = {
     'remember and understand': taxonomy.taxons['remember and understand'].verbs,
     'apply and analyze': taxonomy.taxons['apply and analyze'].verbs,
@@ -9,6 +9,23 @@ const verbs = {
 }
 export class OutcomeWriteDTO {
 
+
+    @ApiProperty({
+        name: 'verb',
+        description: 'Verb within given Bloom\'s Taxonomy for the Learning Outcome',
+        required: true,
+        type: String,
+        isArray: false,
+    })
+    @IsDefined()
+    @IsNotEmpty()
+    @IsString()
+    verb: string;
+    @IsVerbInBloom("verb", {
+        message: "Verb must be in list of verbs for Bloom",
+    })
+
+    
     @ApiProperty({
         name: 'bloom',
         description: 'Bloom\'s Taxonomy for the Learning Outcome',
@@ -24,8 +41,6 @@ export class OutcomeWriteDTO {
     bloom: string;
 
 
-
-
     @ApiProperty({
         name: 'text',
         description: 'Text for the Learning Outcome',
@@ -37,21 +52,5 @@ export class OutcomeWriteDTO {
     @IsString()
     @MaxLength(1000)
     text: string;
- 
-
-
-
-    @ApiProperty({
-        name: 'verb',
-        description: 'Verb within given Bloom\'s Taxonomy for the Learning Outcome',
-        required: true,
-        type: String,
-        isArray: false,
-    })
-    @IsDefined()
-    @IsNotEmpty()
-    @IsString()
-    @IsIn(verbs[this.bloom])
-    verb: string;
 
 }

--- a/src/DTO/verbValidation.ts
+++ b/src/DTO/verbValidation.ts
@@ -1,0 +1,32 @@
+import {registerDecorator, ValidationOptions, ValidationArguments} from "class-validator";
+import { taxonomy } from '@cyber4all/clark-taxonomy';
+const verbs = {
+    'remember and understand': taxonomy.taxons['remember and understand'].verbs,
+    'apply and analyze': taxonomy.taxons['apply and analyze'].verbs,
+    'evaluate and synthesize': taxonomy.taxons['evaluate and synthesize'].verbs,
+}
+/**
+ * This decorator will take the bloom and verb and validate the verb exists in the list of verbs
+ * for that bloom
+ * @param bloom The bloom of the outcome
+ * @param validationOptions 
+ */
+export function IsVerbInBloom(bloom: string, validationOptions?: ValidationOptions) {
+   return function (object: Record<string, any>, verb: string) {
+        registerDecorator({
+            name: "IsVerbInBloom",
+            target: object.constructor,
+            propertyName: verb,
+            constraints: [bloom],
+            options: validationOptions,
+            validator: {
+                validate(value: any, args: ValidationArguments) {
+                    const [relatedPropertyName] = args.constraints;
+                    const verb = (args.object as any)[relatedPropertyName];
+                    const valid = verbs[value].includes(verb);
+                    return valid;
+                }
+            }
+        });
+   };
+}

--- a/src/DTO/verbValidation.ts
+++ b/src/DTO/verbValidation.ts
@@ -7,7 +7,8 @@ const verbs = {
 }
 /**
  * This decorator will take the bloom and verb and validate the verb exists in the list of verbs
- * for that bloom
+ * for that bloom.
+ * Reference class-validator docs: https://github.com/typestack/class-validator
  * @param bloom The bloom of the outcome
  * @param validationOptions 
  */


### PR DESCRIPTION
This PR adds verification that the selected verb is within the list of verbs for the bloom of the outcome. Currently, this is handled by the client but verification should also happen server side in case we need to build a different client so we don't have to rewrite the validation logic. If this is approved before our deployment on Monday I will merge it in prior. 