### PR TITLE
Add delete all outcomes route

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1875,14 +1875,6 @@
       "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
       "dev": true
     },
-    "@types/jsonfile": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@types/jsonfile/-/jsonfile-4.0.2.tgz",
-      "integrity": "sha512-t2mJsD2YCfEPxqJKND4TubLMBdIPcMZS3UdjlUhZLL+vQceptLgrd2nBRUlP/8/YcgM4wC9PWXWKW3Nb1kFS4Q==",
-      "requires": {
-        "@types/node": "*"
-      }
-    },
     "@types/jsonwebtoken": {
       "version": "8.3.8",
       "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-8.3.8.tgz",
@@ -6046,7 +6038,8 @@
     "graceful-fs": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
-      "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ=="
+      "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
+      "dev": true
     },
     "growly": {
       "version": "1.3.0",
@@ -9641,6 +9634,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+      "dev": true,
       "requires": {
         "graceful-fs": "^4.1.6"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "outcome-service",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "outcome-service",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "",
   "author": "",
   "license": "MIT",

--- a/src/outcomes/delete-outcomes.route.spec.ts
+++ b/src/outcomes/delete-outcomes.route.spec.ts
@@ -1,0 +1,7 @@
+import * as request from 'superagent';
+
+describe('When the endpoint DELETE /users/:username/learning-objects/:learningObjectID/outcomes is invoked', () => {
+    it('should return HTTP status code 204', () => {
+
+    });
+});

--- a/src/outcomes/outcomes.controller.ts
+++ b/src/outcomes/outcomes.controller.ts
@@ -78,6 +78,7 @@ export class OutcomesController {
   async deleteOutcomesForLearningObject(@Param() routeParameterDTO: RouteParameterDTO, @Req() request: Request): Promise<void> {
 
     const user = await this.getUser(routeParameterDTO.username);
+    console.log(user);
   
     const learningObject = await this.getLearningObject(routeParameterDTO.username, routeParameterDTO.learningObjectID, request.headers.authorization);
 

--- a/src/outcomes/outcomes.controller.ts
+++ b/src/outcomes/outcomes.controller.ts
@@ -78,9 +78,6 @@ export class OutcomesController {
   async deleteOutcomesForLearningObject(@Param() routeParameterDTO: RouteParameterDTO, @Req() request: Request): Promise<void> {
 
     const user = await this.getUser(routeParameterDTO.username);
-    console.log(user);
-  
-    const learningObject = await this.getLearningObject(routeParameterDTO.username, routeParameterDTO.learningObjectID, request.headers.authorization);
 
     const outcomes = await this.outcomeService.findOutcomesForLearningObject(routeParameterDTO.learningObjectID);
      

--- a/src/outcomes/outcomes.controller.ts
+++ b/src/outcomes/outcomes.controller.ts
@@ -75,7 +75,7 @@ export class OutcomesController {
   @UsePipes(ValidationPipe)
   @UseGuards(JwtAuthGuard)
   @HttpCode(204)
-  async deleteOutcomesForLearningObject(@Param() routeParameterDTO: RouteParameterDTO, @Req() request: Request): Promise<OutcomeReadDTO[]> {
+  async deleteOutcomesForLearningObject(@Param() routeParameterDTO: RouteParameterDTO, @Req() request: Request): Promise<void> {
 
     const user = await this.getUser(routeParameterDTO.username);
   

--- a/src/outcomes/outcomes.controller.ts
+++ b/src/outcomes/outcomes.controller.ts
@@ -75,7 +75,7 @@ export class OutcomesController {
   @UsePipes(ValidationPipe)
   @UseGuards(JwtAuthGuard)
   @HttpCode(204)
-  async deleteOutcomesForLearningObject(@Param() routeParameterDTO: RouteParameterDTO, @Req() request: Request): Promise<void> {
+  async deleteOutcomesForLearningObject(@Param() routeParameterDTO: RouteParameterDTO): Promise<void> {
 
     const user = await this.getUser(routeParameterDTO.username);
 

--- a/src/outcomes/outcomes.controller.ts
+++ b/src/outcomes/outcomes.controller.ts
@@ -67,6 +67,25 @@ export class OutcomesController {
     return outcomeResponses;
   }
 
+  @ApiOkResponse({ description: 'OK' })
+  @ApiBadRequestResponse({ description: 'Invalid username' })
+  @ApiForbiddenResponse({ description: 'If the object is unreleased and requester is not the author || If the object is waiting, review, or proofing and the requester is not privileged' })
+  @ApiNotFoundResponse({ description: 'User is not found || Learning Object is not found' })
+  @Delete('/users/:username/learning-objects/:learningObjectID/outcomes')
+  @UsePipes(ValidationPipe)
+  @UseGuards(JwtAuthGuard)
+  @HttpCode(204)
+  async deleteOutcomesForLearningObject(@Param() routeParameterDTO: RouteParameterDTO, @Req() request: Request): Promise<OutcomeReadDTO[]> {
+
+    const user = await this.getUser(routeParameterDTO.username);
+  
+    const learningObject = await this.getLearningObject(routeParameterDTO.username, routeParameterDTO.learningObjectID, request.headers.authorization);
+
+    const outcomes = await this.outcomeService.findOutcomesForLearningObject(routeParameterDTO.learningObjectID);
+     
+    await this.outcomeService.deleteOutcomesForLearningObject(routeParameterDTO.learningObjectID);
+  }
+
   @ApiBadRequestResponse({ description: 'Invalid bloom || Invalid verb || Invalid username'})
   @ApiUnauthorizedResponse({ description: 'If the requester is not signed in' })
   @ApiForbiddenResponse({ description: 'If the Learning Object is unreleased and the requester is not the author || If the Learning Object is in waiting, review, or proofing and requester is not privileged || If the object is released' })

--- a/src/outcomes/outcomes.service.ts
+++ b/src/outcomes/outcomes.service.ts
@@ -16,6 +16,10 @@ export class OutcomesService {
         return this.outcomeModel.find({ learningObjectId }).exec();
     }
 
+    async deleteOutcomesForLearningObject(learningObjectId: string) {
+        return this.outcomeModel.deleteMany({ learningObjectId: learningObjectId}).exec();
+    }
+
     async create(outcomeWriteDTO: OutcomeWriteDTO, learningObjectId: string ): Promise<void> {
       const createdOutcome = new this.outcomeModel({ ...outcomeWriteDTO, learningObjectId, lastUpdated: Date.now(), _id: new Types.ObjectId() });
       await createdOutcome.save();


### PR DESCRIPTION
This PR adds a route to delete all of the outcomes for a given learning object. This is currently only be used by learning-object service. 